### PR TITLE
For reasons unkown,  it was returning an error if an index already

### DIFF
--- a/elasticsearch/index.go
+++ b/elasticsearch/index.go
@@ -112,7 +112,8 @@ func (esi *Index) Create() error {
 
 	ok := esi.IndexExists()
 	if ok {
-		return fmt.Errorf("Index %s already exists", esi.index)
+		//return fmt.Errorf("Index %s already exists", esi.index)
+		return nil
 	}
 
 	createIndex, err := esi.lib.CreateIndex(esi.index).Do()


### PR DESCRIPTION
existed.   Just returning nil until we can can figure out why.