### PR TITLE
5547 event dsl query

### DIFF
--- a/elasticsearch/common.go
+++ b/elasticsearch/common.go
@@ -84,7 +84,7 @@ type IIndex interface {
 	GetAllElements(typ string) (*SearchResult, error)
 	FilterByTermQuery(typ string, name string, value interface{}) (*SearchResult, error)
 	FilterByMatchQuery(typ string, name string, value interface{}) (*SearchResult, error)
-	SearchByJSON(typ string, jsn string) (*SearchResult, error)
+	SearchByJSON(typ string, jsn string, format *piazza.JsonPagination) (*SearchResult, error)
 	SetMapping(typename string, jsn piazza.JsonString) error
 	GetTypes() ([]string, error)
 	GetMapping(typ string) (interface{}, error)

--- a/elasticsearch/common.go
+++ b/elasticsearch/common.go
@@ -84,7 +84,7 @@ type IIndex interface {
 	GetAllElements(typ string) (*SearchResult, error)
 	FilterByTermQuery(typ string, name string, value interface{}) (*SearchResult, error)
 	FilterByMatchQuery(typ string, name string, value interface{}) (*SearchResult, error)
-	SearchByJSON(typ string, jsn string, format *piazza.JsonPagination) (*SearchResult, error)
+	SearchByJSON(typ string, jsn string) (*SearchResult, error)
 	SetMapping(typename string, jsn piazza.JsonString) error
 	GetTypes() ([]string, error)
 	GetMapping(typ string) (interface{}, error)

--- a/elasticsearch/index.go
+++ b/elasticsearch/index.go
@@ -372,17 +372,6 @@ func (esi *Index) FilterByMatchQuery(typ string, name string, value interface{})
 
 // SearchByJSON performs a search over the index via raw JSON.
 func (esi *Index) SearchByJSON(typ string, jsn string) (*SearchResult, error) {
-	/*if typ == "" {
-		return nil, fmt.Errorf("Can't filter on type \"\"")
-	}
-	ok, err := esi.TypeExists(typ)
-	if err != nil {
-		return nil, err
-	}
-	if !ok {
-		return nil, fmt.Errorf("Type %s in index %s does not exist", typ, esi.index)
-	}*/
-
 	var obj interface{}
 	err := json.Unmarshal([]byte(jsn), &obj)
 	if err != nil {
@@ -394,16 +383,6 @@ func (esi *Index) SearchByJSON(typ string, jsn string) (*SearchResult, error) {
 		Type(typ).
 		Source(obj).
 		Do()
-	//if format != nil {
-	//	queryFormat := NewQueryFormat(format)
-	// TODO: Check the jsn string for size and from and override those params
-	//    Otherwise use what was given in the JsonPagination
-	//	searchService.
-	//		From(queryFormat.From).
-	//		Size(queryFormat.Size).
-	//		Sort(queryFormat.Key, queryFormat.Order)
-	//}
-	//searchResult, err := searchService.Do()
 	if err != nil {
 		return nil, err
 	}

--- a/elasticsearch/index.go
+++ b/elasticsearch/index.go
@@ -371,7 +371,7 @@ func (esi *Index) FilterByMatchQuery(typ string, name string, value interface{})
 }
 
 // SearchByJSON performs a search over the index via raw JSON.
-func (esi *Index) SearchByJSON(typ string, jsn string, format *piazza.JsonPagination) (*SearchResult, error) {
+func (esi *Index) SearchByJSON(typ string, jsn string) (*SearchResult, error) {
 	/*if typ == "" {
 		return nil, fmt.Errorf("Can't filter on type \"\"")
 	}
@@ -389,20 +389,21 @@ func (esi *Index) SearchByJSON(typ string, jsn string, format *piazza.JsonPagina
 		return nil, err
 	}
 
-	searchService := esi.lib.Search().
+	searchResult, err := esi.lib.Search().
 		Index(esi.index).
 		Type(typ).
-		Source(obj)
-	if format != nil {
-		queryFormat := NewQueryFormat(format)
-		// TODO: Check the jsn string for size and from and override those params
-		//    Otherwise use what was given in the JsonPagination
-		searchService.
-			From(queryFormat.From).
-			Size(queryFormat.Size).
-			Sort(queryFormat.Key, queryFormat.Order)
-	}
-	searchResult, err := searchService.Do()
+		Source(obj).
+		Do()
+	//if format != nil {
+	//	queryFormat := NewQueryFormat(format)
+	// TODO: Check the jsn string for size and from and override those params
+	//    Otherwise use what was given in the JsonPagination
+	//	searchService.
+	//		From(queryFormat.From).
+	//		Size(queryFormat.Size).
+	//		Sort(queryFormat.Key, queryFormat.Order)
+	//}
+	//searchResult, err := searchService.Do()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I'm thinking we might want to send in a boolean "allowEmptyTyp" or something like that and put those first checks back in.

Not sure what the ramifications of removing that would be for other things